### PR TITLE
Bump the pip group across 1 directories with 1 update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles
 bard
 SpeechRecognition
 pornhub-api==0.2.0
-aiohttp==3.9.1
+aiohttp==3.9.2
 asyncio==3.4.3
 beautifulsoup4
 daxxhub


### PR DESCRIPTION
Bumps the pip group with 1 update in the /. directory: [aiohttp](https://github.com/aio-libs/aiohttp).


Updates `aiohttp` from 3.9.1 to 3.9.2
- [Release notes](https://github.com/aio-libs/aiohttp/releases)
- [Changelog](https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst)
- [Commits](https://github.com/aio-libs/aiohttp/compare/v3.9.1...v3.9.2)

---
updated-dependencies:
- dependency-name: aiohttp dependency-type: direct:production dependency-group: pip-security-group ...